### PR TITLE
MPP-505 bulk action fix

### DIFF
--- a/src/CrispBulkActions.js
+++ b/src/CrispBulkActions.js
@@ -15,7 +15,7 @@ export default class CrispBulkActions extends React.Component {
   }
 
   getSelectedIds = () => {
-    return (this.state.selectedRows || []).map(row => row.id);
+    return (this.context.selectedRows || []).map(row => row.id);
   }
 
   handleBulkAction = (e) => {


### PR DESCRIPTION
Without this change getSelectedIds returns single id instead of the list of selected rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state management structure to improve code maintainability and streamline how selected items are accessed throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->